### PR TITLE
Add auto versioning and changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Bump version
+        run: npm version patch
+
+      - name: Update changelog
+        run: npm run version
+
+      - name: Commit changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add .
+          git commit -m 'ci: bump version and update changelog'
+          git push
+
+      - name: Publish to NPM
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/changelog.json
+++ b/changelog.json
@@ -1,0 +1,4 @@
+{
+  "output": "CHANGELOG.md",
+  "template": "keepachangelog"
+}

--- a/package.json
+++ b/package.json
@@ -18,12 +18,24 @@
   "homepage": "https://github.com/tctien342/comfyui-sdk#readme",
   "devDependencies": {
     "@types/bun": "latest",
-    "dts-bundle-generator": "^9.5.1"
+    "dts-bundle-generator": "^9.5.1",
+    "auto-changelog": "^2.3.0",
+    "commitizen": "^4.2.4",
+    "cz-conventional-changelog": "^3.3.0"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"
   },
   "dependencies": {
     "ws": "^8.18.0"
+  },
+  "scripts": {
+    "version": "auto-changelog -p",
+    "commit": "git-cz"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }


### PR DESCRIPTION
Add GitHub Actions workflow to automate NPM versioning and changelog updates.

* **package.json**
  - Add `auto-changelog`, `commitizen`, and `cz-conventional-changelog` to `devDependencies`.
  - Add `version` script to run `auto-changelog -p`.
  - Add `commit` script to run `git-cz`.
  - Add `commitizen` configuration to use `cz-conventional-changelog`.

* **.github/workflows/release.yml**
  - Create a GitHub Actions workflow file.
  - Add steps to trigger on push to `main` branch.
  - Add steps to build the project.
  - Add steps to increment the version.
  - Add steps to update the changelog.
  - Add steps to publish the new NPM version.

* **changelog.json**
  - Add a configuration file for `auto-changelog`.
  - Set `output` to `CHANGELOG.md`.
  - Set `template` to `keepachangelog`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tctien342/comfyui-sdk?shareId=b704b4f4-7cd4-48e4-86ed-30ea246d98bd).