### PR TITLE
fix(client): fix onmessage buffer slicing

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -929,7 +929,7 @@ export class ComfyApi extends EventTarget {
                 case 2:
                   imageMime = "image/png";
               }
-              const imageBlob = new Blob([buffer.slice(4)], {
+              const imageBlob = new Blob([buffer.slice(8)], {
                 type: imageMime,
               });
               this.dispatchEvent(


### PR DESCRIPTION
When inspecting the incoming message from the server, it seems only the eventType is sliced off, and the imageType data is left in, resulting in corrupted preview images.
I've modified it so 8 bytes are removed, instead of 4.