### PR TITLE
feat(caller): watch queue status changes

### DIFF
--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -1,0 +1,31 @@
+export class CallWrapperError extends Error {
+  name = 'CallWrapperError';
+}
+
+export class WentMissingError extends CallWrapperError {
+  name = 'WentMissingError';
+}
+
+export class FailedCacheError extends CallWrapperError {
+  name = 'FailedCacheError';
+}
+
+export class EnqueueFailedError extends CallWrapperError {
+  name = 'EnqueueFailedError';
+}
+
+export class DisconnectedError extends CallWrapperError {
+  name = 'DisconnectedError';
+}
+
+export class ExecutionFailedError extends CallWrapperError {
+  name = 'ExecutionFailedError';
+}
+
+export class CustomEventError extends CallWrapperError {
+  name = 'CustomEventError';
+}
+
+export class ExecutionInterruptedError extends CallWrapperError {
+  name = ' ExecutionInterruptedError';
+}

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -41,6 +41,12 @@ export type TExecutionError = TExecution & {
   traceback: string[];
 };
 
+export type TExecutionInterrupted = TExecution & {
+  node_id: string;
+  node_type: string;
+  executed: string[],
+};
+
 export type TEventKey =
   | "all"
   | "auth_error"
@@ -81,6 +87,7 @@ export type TComfyAPIEventMap = {
   executed: CustomEvent<TExecuted>;
   queue_error: CustomEvent<Error>;
   execution_error: CustomEvent<TExecutionError>;
+  execution_interrupted: CustomEvent<TExecutionInterrupted>;
   execution_cached: CustomEvent<TExecutionCached>;
 };
 


### PR DESCRIPTION
I have added watching the "status" event for checking if the prompt is still in the queue, and calling onFailed if not.
I have also by necessity refactored the event handling of run(), it now relies on promises, this had the side effect of removing the delay calls, causing noticeable speedup at job startup.
I've also added custom error classes for call wrapper, so the library's end users can distinguish between failed jobs' errors if need be. It should resolve issue #9.