### PR TITLE
feat(builder): bypass nodes

### DIFF
--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -1,14 +1,15 @@
 import { encodeNTPath, encodePosixPath } from "./tools";
-import { OSType } from "./types/api";
+import { NodeData, OSType } from "./types/api";
 import { DeepKeys, Simplify } from "./types/tool";
 
-export class PromptBuilder<I extends string, O extends string, T = unknown> {
+export class PromptBuilder<I extends string, O extends string, T extends NodeData> {
   prompt: T;
   mapInputKeys: Partial<Record<I, string | string[]>> = {};
   mapOutputKeys: Partial<Record<O, string>> = {};
+  bypassNodes: (keyof T)[] = [];
 
   constructor(prompt: T, inputKeys: I[], outputKeys: O[]) {
-    this.prompt = prompt;
+    this.prompt = structuredClone(prompt);
     inputKeys.forEach((key) => {
       this.mapInputKeys[key] = undefined;
     });
@@ -31,6 +32,57 @@ export class PromptBuilder<I extends string, O extends string, T = unknown> {
     );
     newBuilder.mapInputKeys = { ...this.mapInputKeys };
     newBuilder.mapOutputKeys = { ...this.mapOutputKeys };
+    newBuilder.bypassNodes = [ ...this.bypassNodes ];
+    return newBuilder;
+  }
+
+
+  /**
+   * Marks a node to be bypassed at generation.
+   *
+   * @param node Node which will be bypassed.
+   */
+  bypass(node: keyof T): PromptBuilder<I, O, T>;
+
+  /**
+   * Marks multiple nodes to be bypassed at generation.
+   *
+   * @param nodes Array of nodes which will be bypassed.
+   */
+  bypass(nodes: (keyof T)[]): PromptBuilder<I, O, T>;
+
+  bypass(nodes: keyof T | (keyof T)[]) {
+    if (!Array.isArray(nodes)) {
+      nodes = [nodes];
+    }
+    const newBuilder = this.clone();
+    newBuilder.bypassNodes.push(...nodes);
+    return newBuilder;
+  }
+
+  /**
+   * Unmarks a node from bypass at generation.
+   *
+   * @param node Node to reverse bypass on.
+   */
+  reinstate(node: keyof T): PromptBuilder<I, O, T>;
+
+  /**
+   * Unmarks a collection of nodes from bypass at generation.
+   *
+   * @param nodes Array of nodes to reverse bypass on.
+   */
+  reinstate(nodes: (keyof T)[]): PromptBuilder<I, O, T>;
+
+  reinstate(nodes: keyof T | (keyof T)[]) {
+    if (!Array.isArray(nodes)) {
+      nodes = [nodes];
+    }
+
+    const newBuilder = this.clone();
+    for (const node of nodes) {
+      newBuilder.bypassNodes.splice(newBuilder.bypassNodes.indexOf(node), 1);
+    }
     return newBuilder;
   }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -123,12 +123,21 @@ export interface NodeDef {
         | TBoolInput
         | TNumberInput;
     };
+    optional?: {
+      [key: string]:
+        | [string[], { tooltip?: string }]
+        | [string, { tooltip?: string }]
+        | TStringInput
+        | TBoolInput
+        | TNumberInput;
+    };
     hidden: {
       [key: string]: string;
     };
   };
   input_order: {
     required: string[];
+    optional?: string[],
     hidden: string[];
   };
   output: string[];

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -27,5 +27,9 @@ export class CustomEventError extends CallWrapperError {
 }
 
 export class ExecutionInterruptedError extends CallWrapperError {
-  name = ' ExecutionInterruptedError';
+  name = 'ExecutionInterruptedError';
+}
+
+export class MissingNodeError extends CallWrapperError {
+  name = 'MissingNodeError';
 }


### PR DESCRIPTION
I've found out much to my chagrin that ComfyUI is in fact not turing complete, and the bypass functionality is only on the ComfyUI frontend, and is in fact not programmable.

This necessitates handling turning on and off nodes before they are sent to the API. I've added a `bypass()` and `reinstate()` method to the prompt builder, enabling users to conditionally bypass nodes.

This change necessitated some changes to types, most significantly the type of `prompt` has been specified to extend NodeData. It also requires querying the server for node definitions in order to determine the types of outputs and inputs of a node before it can be bypassed.

I've also modified prompt builder to clone the workflow every time prompt builder is cloned, as previously the original workflow was modified by `input()` and would have been further modified by the bypass functionality, which led to some strange mutation issues when two jobs of the same workflow were sent to the server. I've used `structuredClone()` for this, which should be covered by the `lib` settings already present in `tsconfig.json`.

NodeDef has also been extended to include `optional` properties, as these are necessary for bypassing. A new error class called MissingNodeError was added, in case bypassed nodes are not present in the workflow.